### PR TITLE
na-boxed: redundant redeclaration of 'bool_to_string'

### DIFF
--- a/src/core/na-boxed.c
+++ b/src/core/na-boxed.c
@@ -106,7 +106,6 @@ static void            bool_from_void( NABoxed *boxed, const void *value );
 static gchar          *bool_to_string( const NABoxed *boxed );
 static gboolean        bool_to_bool( const NABoxed *boxed );
 static gconstpointer   bool_to_pointer( const NABoxed *boxed );
-static gchar          *bool_to_string( const NABoxed *boxed );
 static void            bool_to_value( const NABoxed *boxed, GValue *value );
 static void           *bool_to_void( const NABoxed *boxed );
 


### PR DESCRIPTION
```
na-boxed.c:109:24: warning: redundant redeclaration of 'bool_to_string' [-Wredundant-decls]
  109 | static gchar          *bool_to_string( const NABoxed *boxed );
      |                        ^~~~~~~~~~~~~~
na-boxed.c:106:24: note: previous declaration of 'bool_to_string' was here
  106 | static gchar          *bool_to_string( const NABoxed *boxed );
      |                        ^~~~~~~~~~~~~~
```