### PR TITLE
Remove shadow warnings [-Wshadow]

### DIFF
--- a/src/core/na-factory-object.c
+++ b/src/core/na-factory-object.c
@@ -166,16 +166,13 @@ define_class_properties_iter( const NADataDef *def, GObjectClass *class )
 NADataDef *
 na_factory_object_get_data_def( const NAIFactoryObject *object, const gchar *name )
 {
-	NADataDef *def;
+	NADataDef *def = NULL;
 
 	g_return_val_if_fail( NA_IS_IFACTORY_OBJECT( object ), NULL );
 
-	def = NULL;
-
 	NADataGroup *groups = v_get_groups( object );
 	while( groups->group ){
-
-		NADataDef *def = groups->def;
+		def = groups->def;
 		if( def ){
 			while( def->name ){
 

--- a/src/utils/caja-actions-print.c
+++ b/src/utils/caja-actions-print.c
@@ -194,33 +194,32 @@ init_options( void )
  * search for the action in the repository
  */
 static NAObjectItem *
-get_item( const gchar *id )
+get_item (const gchar *item_id)
 {
 	NAObjectItem *item = NULL;
 
-	pivot = na_pivot_new();
-	na_pivot_set_loadable( pivot, PIVOT_LOAD_ALL );
-	na_pivot_load_items( pivot );
+	pivot = na_pivot_new ();
+	na_pivot_set_loadable (pivot, PIVOT_LOAD_ALL);
+	na_pivot_load_items (pivot);
 
-	item = na_pivot_get_item( pivot, id );
-
-	if( !item ){
-		g_printerr( _( "Error: item '%s' doesn't exist.\n" ), id );
+	if ((item = na_pivot_get_item (pivot, item_id)) == NULL) {
+		g_printerr (_( "Error: item '%s' doesn't exist.\n" ), item_id);
 	}
 
-	return( item );
+	return item;
 }
 
 /*
  * displays the specified item on stdout, in the specified export format
  */
 static void
-export_item( const NAObjectItem *item, const gchar *format )
+export_item (const NAObjectItem *item,
+             const gchar        *format_str)
 {
 	GSList *messages = NULL;
 	GSList *it;
 
-	gchar *buffer = na_exporter_to_buffer( pivot, item, format, &messages );
+	gchar *buffer = na_exporter_to_buffer( pivot, item, format_str, &messages );
 
 	for( it = messages ; it ; it = it->next ){
 		g_printerr( "%s\n", ( const gchar * ) it->data );

--- a/src/utils/caja-actions-run.c
+++ b/src/utils/caja-actions-run.c
@@ -213,36 +213,33 @@ init_options( void )
  * search for the action in the repository
  */
 static NAObjectAction *
-get_action( const gchar *id )
+get_action (const gchar *action_id)
 {
 	NAPivot *pivot;
-	NAObjectAction *action;
+	NAObjectAction *action = NULL;
 
-	action = NULL;
+	pivot = na_pivot_new ();
+	na_pivot_set_loadable (pivot, !PIVOT_LOAD_DISABLED & !PIVOT_LOAD_INVALID);
+	na_pivot_load_items (pivot);
 
-	pivot = na_pivot_new();
-	na_pivot_set_loadable( pivot, !PIVOT_LOAD_DISABLED & !PIVOT_LOAD_INVALID );
-	na_pivot_load_items( pivot );
+	action = (NAObjectAction *) na_pivot_get_item (pivot, action_id);
 
-	action = ( NAObjectAction * ) na_pivot_get_item( pivot, id );
-
-	if( !action ){
-		g_printerr( _( "Error: action '%s' doesn't exist.\n" ), id );
-
+	if(!action){
+		g_printerr (_("Error: action '%s' doesn't exist.\n"), action_id);
 	} else {
-		if( !na_object_is_enabled( action )){
-			g_printerr( _( "Error: action '%s' is disabled.\n" ), id );
-			g_object_unref( action );
+		if (!na_object_is_enabled (action)){
+			g_printerr (_("Error: action '%s' is disabled.\n"), action_id);
+			g_object_unref (action);
 			action = NULL;
 		}
-		if( !na_object_is_valid( action )){
-			g_printerr( _( "Error: action '%s' is not valid.\n" ), id );
-			g_object_unref( action );
+		if (!na_object_is_valid (action)){
+			g_printerr (_( "Error: action '%s' is not valid.\n"), action_id);
+			g_object_unref (action);
 			action = NULL;
 		}
 	}
 
-	return( action );
+	return action;
 }
 
 /*


### PR DESCRIPTION
```
na-factory-object.c:178:14: warning: declaration of ‘def’ shadows a previous local [-Wshadow]
  178 |   NADataDef *def = groups->def;
      |              ^~~
--
caja-actions-print.c:197:24: warning: declaration of ‘id’ shadows a global declaration [-Wshadow]
  197 | get_item( const gchar *id )
      |           ~~~~~~~~~~~~~^~
--
caja-actions-print.c:218:53: warning: declaration of ‘format’ shadows a global declaration [-Wshadow]
  218 | export_item( const NAObjectItem *item, const gchar *format )
      |                                        ~~~~~~~~~~~~~^~~~~~
--
caja-actions-run.c:216:26: warning: declaration of ‘id’ shadows a global declaration [-Wshadow]
  216 | get_action( const gchar *id )
      |             ~~~~~~~~~~~~~^~
```