### PR TITLE
cact-ienvironment-tab: variable 'state' is uninitialized

### DIFF
--- a/src/cact/cact-ienvironment-tab.c
+++ b/src/cact/cact-ienvironment-tab.c
@@ -698,7 +698,7 @@ on_desktop_toggled( GtkCellRendererToggle *renderer, gchar *path, BaseWindow *wi
 	GtkTreeModel *model;
 	GtkTreeIter iter;
 	GtkTreePath *tree_path;
-	gboolean state;
+	gboolean state = FALSE;
 	gchar *desktop;
 	GtkWidget *show_button;
 	IEnvironData *data;


### PR DESCRIPTION
```
cact-ienvironment-tab.c:738:52: warning: variable 'state' is uninitialized when used here [-Wuninitialized]
                                gtk_cell_renderer_toggle_set_active( renderer, state );
                                                                               ^~~~~
cact-ienvironment-tab.c:701:16: note: initialize the variable 'state' to silence this warning
        gboolean state;
                      ^
                       = 0
```