### PR TITLE
na-selected-info: fix memory leak

### DIFF
--- a/src/core/na-selected-info.c
+++ b/src/core/na-selected-info.c
@@ -875,7 +875,7 @@ query_file_attributes( NASelectedInfo *nsi, GFile *location, gchar **errmsg )
 	}
 
 	if( !nsi->private->mimetype ){
-		nsi->private->mimetype = g_strdup( g_file_info_get_attribute_as_string( info, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE ));
+		nsi->private->mimetype = g_file_info_get_attribute_as_string( info, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE );
 	}
 
 	nsi->private->file_type = ( GFileType ) g_file_info_get_attribute_uint32( info, G_FILE_ATTRIBUTE_STANDARD_TYPE );
@@ -884,7 +884,7 @@ query_file_attributes( NASelectedInfo *nsi, GFile *location, gchar **errmsg )
 	nsi->private->can_write = g_file_info_get_attribute_boolean( info, G_FILE_ATTRIBUTE_ACCESS_CAN_WRITE );
 	nsi->private->can_execute = g_file_info_get_attribute_boolean( info, G_FILE_ATTRIBUTE_ACCESS_CAN_EXECUTE );
 
-	nsi->private->owner = g_strdup( g_file_info_get_attribute_as_string( info, G_FILE_ATTRIBUTE_OWNER_USER ));
+	nsi->private->owner = g_file_info_get_attribute_as_string( info, G_FILE_ATTRIBUTE_OWNER_USER );
 
 	nsi->private->attributes_are_set = TRUE;
 


### PR DESCRIPTION
```
LeakSanitizer: detected memory leaks

Direct leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7fae5c08793f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fae5ad664ff in g_malloc ../glib/gmem.c:106
    #2 0x7fae5ad66842 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fae5ad88d85 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x7fae5af46f10 in _g_file_attribute_value_as_string ../gio/gfileattribute.c:339
    #5 0x7fae5af4cd64 in g_file_info_get_attribute_as_string ../gio/gfileinfo.c:856
    #6 0x7fae46cc1764 in query_file_attributes /home/robert/builddir.gcc/caja-actions/src/core/na-selected-info.c:887
    #7 0x7fae46cc1133 in new_from_uri /home/robert/builddir.gcc/caja-actions/src/core/na-selected-info.c:843
    #8 0x7fae46cc0adb in new_from_caja_file_info /home/robert/builddir.gcc/caja-actions/src/core/na-selected-info.c:742
    #9 0x7fae46cbe669 in na_selected_info_get_list_from_item /home/robert/builddir.gcc/caja-actions/src/core/na-selected-info.c:219
    #10 0x7fae46d40ed1 in menu_provider_get_toolbar_items /home/robert/builddir.gcc/caja-actions/src/plugin-menu/caja-actions.c:450
    #11 0x7fae5bfa2754 in caja_menu_provider_get_toolbar_items /home/robert/builddir.gcc/caja/libcaja-extension/caja-menu-provider.c:150
    #12 0x4e266d in get_extension_toolbar_items /home/robert/builddir.gcc/caja/src/caja-window-toolbars.c:135
    #13 0x4e2a42 in caja_navigation_window_load_extension_toolbar_items /home/robert/builddir.gcc/caja/src/caja-window-toolbars.c:186
    #14 0x4d7619 in update_for_new_location /home/robert/builddir.gcc/caja/src/caja-window-manage-views.c:1917
    #15 0x4d65b5 in location_has_really_changed /home/robert/builddir.gcc/caja/src/caja-window-manage-views.c:1645
    #16 0x4d6098 in caja_window_report_load_underway /home/robert/builddir.gcc/caja/src/caja-window-manage-views.c:1563
    #17 0x692ef3 in caja_window_info_report_load_underway /home/robert/builddir.gcc/caja/libcaja-private/caja-window-info.c:134
    #18 0x523f87 in finish_loading /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9745
    #19 0x52455b in finish_loading_if_all_metadata_loaded /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9807
    #20 0x524a7b in metadata_for_files_in_directory_ready_callback /home/robert/builddir.gcc/caja/src/file-manager/fm-directory-view.c:9843
    #21 0x5ac400 in ready_callback_call /home/robert/builddir.gcc/caja/libcaja-private/caja-directory-async.c:1388
    #22 0x5af586 in call_ready_callbacks_at_idle /home/robert/builddir.gcc/caja/libcaja-private/caja-directory-async.c:2031
    #23 0x7fae5ad57f2e in g_idle_dispatch ../glib/gmain.c:5929
    #24 0x7fae5ad5d136 in g_main_dispatch ../glib/gmain.c:3413
    #25 0x7fae5ad5cf7f in g_main_context_dispatch ../glib/gmain.c:4131
    #26 0x7fae5ad5d4a1 in g_main_context_iterate ../glib/gmain.c:4207
    #27 0x7fae5ad5d522 in g_main_context_iteration ../glib/gmain.c:4272
    #28 0x7fae5aff5cee in g_application_run ../gio/gapplication.c:2569
    #29 0x47d7ba in main /home/robert/builddir.gcc/caja/src/caja-main.c:271
```